### PR TITLE
Added Closet Gallery recycler view with Edit capabilities

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,4 +39,5 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     implementation 'android.arch.navigation:navigation-fragment:1.0.0-rc02'
+    implementation 'com.android.support:recyclerview-v7:28.0.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,8 @@
             android:supportsRtl="true"
             android:theme="@style/AppTheme"
             tools:ignore="GoogleAppIndexingWarning">
+        <activity android:name=".EditClothing">
+        </activity>
         <activity
                 android:name=".CreateOutfitActivity"
                 android:label="@string/title_activity_create_outfit">

--- a/app/src/main/java/com/cop4331/group7/hangr/ClosetGalleryActivity.kt
+++ b/app/src/main/java/com/cop4331/group7/hangr/ClosetGalleryActivity.kt
@@ -4,9 +4,20 @@ import android.content.Intent
 import android.os.Bundle
 import android.support.design.widget.BottomNavigationView
 import android.support.v7.app.AppCompatActivity
+import android.support.v7.widget.GridLayoutManager
+import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.TextView
 import kotlinx.android.synthetic.main.activity_closet_gallery.*
+import kotlinx.android.synthetic.main.gallery_img_view.view.*
 
 class ClosetGalleryActivity : AppCompatActivity() {
+
+    private lateinit var viewAdapter: RecyclerView.Adapter<*>
+    private lateinit var viewManager: RecyclerView.LayoutManager
 
     // go to activity when navigation button is pressed
     private val mOnNavigationItemSelectedListener = BottomNavigationView.OnNavigationItemSelectedListener { item ->
@@ -33,8 +44,48 @@ class ClosetGalleryActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_closet_gallery)
 
-        navigation.menu.getItem(0).isChecked = true
-
+        // navigation
+        navigation.menu.getItem(1).isChecked = true
         navigation.setOnNavigationItemSelectedListener(mOnNavigationItemSelectedListener)
+
+        // recycler view
+        viewManager = GridLayoutManager(this@ClosetGalleryActivity, 2)
+        viewAdapter = MyAdapter(arrayOf("images", "loaded", "from", "DB", "should", "go", "here"))
+
+        recycler_gallery.apply {
+            layoutManager = viewManager
+            adapter = viewAdapter
+        }
+    }
+
+    class MyAdapter(private val myDataset: Array<String>) :
+        RecyclerView.Adapter<MyAdapter.MyViewHolder>() {
+
+        class MyViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+            var button : LinearLayout = itemView.layout_gallery
+            var placeHolder : TextView = itemView.text_placeholder
+        }
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MyAdapter.MyViewHolder {
+            val view = LayoutInflater.from(parent.context)
+                .inflate(R.layout.gallery_img_view, parent, false)
+
+            return MyViewHolder(view)
+        }
+
+        override fun onBindViewHolder(holder: MyViewHolder, position: Int) {
+            // TODO: get image from DB
+            holder.placeHolder.text = myDataset[position]
+
+            holder.button.setOnLongClickListener {
+                val intent = Intent(it.context, EditClothing::class.java)
+                // TODO: put info regarding the view selected so fields in activity_edit_clothing can be populated
+                // intent.putExtra()
+                it.context.startActivity(intent)
+                true
+            }
+        }
+
+        override fun getItemCount() = myDataset.size
     }
 }

--- a/app/src/main/java/com/cop4331/group7/hangr/EditClothing.kt
+++ b/app/src/main/java/com/cop4331/group7/hangr/EditClothing.kt
@@ -1,0 +1,24 @@
+package com.cop4331.group7.hangr
+
+import android.content.Intent
+import android.support.v7.app.AppCompatActivity
+import android.os.Bundle
+
+class EditClothing : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_edit_clothing)
+
+        // TODO: populate layout fields with info passed to this activity via intents
+        // TODO: if we came from NewClothes, hide delete button
+
+        // TODO: allow user to edit fields or add tags
+
+        // TODO: update DB with new information
+
+        // return to gallery
+        val intent = Intent(this, ClosetGalleryActivity::class.java)
+        startActivity(intent)
+    }
+}

--- a/app/src/main/res/layout/activity_closet_gallery.xml
+++ b/app/src/main/res/layout/activity_closet_gallery.xml
@@ -20,4 +20,18 @@
             app:layout_constraintRight_toRightOf="parent"
             app:menu="@menu/navigation"/>
 
+    <android.support.v7.widget.RecyclerView
+            android:id="@+id/recycler_gallery"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:scrollbars="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:layout_marginBottom="8dp"
+            app:layout_constraintBottom_toTopOf="@+id/navigation"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="8dp"/>
+
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_edit_clothing.xml
+++ b/app/src/main/res/layout/activity_edit_clothing.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+				xmlns:android="http://schemas.android.com/apk/res/android"
+				xmlns:tools="http://schemas.android.com/tools"
+				xmlns:app="http://schemas.android.com/apk/res-auto"
+				android:layout_width="match_parent"
+				android:layout_height="match_parent"
+				tools:context=".EditClothing">
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/gallery_img_view.xml
+++ b/app/src/main/res/layout/gallery_img_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+				xmlns:android="http://schemas.android.com/apk/res/android"
+				xmlns:app="http://schemas.android.com/apk/res-auto"
+				xmlns:tools="http://schemas.android.com/tools"
+				android:id="@+id/layout_gallery"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:orientation="vertical"
+				android:padding="16dp">
+
+	<TextView
+					android:layout_width="match_parent"
+					android:layout_height="40dp"
+					android:textAlignment="center"
+					android:text="filler"
+					android:textSize="17sp"
+					android:id="@+id/text_placeholder"
+					/>
+</LinearLayout>


### PR DESCRIPTION
Squashed commits:

fixed RecycleLayout

long click popup menu for images in gallery

debugging popup menu on long click

created files for editing clothes

added requirements to file

removed menu, long press goes straight to EditClothing

fixed onLongClick in viewholder for gallery